### PR TITLE
Add Verify AuthContext Step

### DIFF
--- a/.azure-pipelines/CICD.yml
+++ b/.azure-pipelines/CICD.yml
@@ -44,6 +44,18 @@ jobs:
       filePath: '..\BCDevOpsFlows\ReadSettings\ReadSettings.ps1'
 
   - task: PowerShell@2
+    displayName: 'Verify Auth Context'
+    condition: succeeded()
+    env:
+      AL_AUTHCONTEXTS_INTERNAL: $(AL_AUTHCONTEXT)
+    inputs:
+      pwsh: true
+      filePath: '..\BCDevOpsFlows\VerifyAuthContext\VerifyAuthContext.ps1'
+      arguments: '-environmentName "$(environmentName)"'
+      warningPreference: 'stop'
+      failOnStderr: true
+      
+  - task: PowerShell@2
     displayName: 'Determine Artifact Url'
     inputs:
       pwsh: true

--- a/.azure-pipelines/PublishToProduction.yml
+++ b/.azure-pipelines/PublishToProduction.yml
@@ -44,6 +44,18 @@ jobs:
       filePath: '..\BCDevOpsFlows\ReadSettings\ReadSettings.ps1'
 
   - task: PowerShell@2
+    displayName: 'Verify Auth Context'
+    condition: succeeded()
+    env:
+      AL_AUTHCONTEXTS_INTERNAL: $(AL_AUTHCONTEXT)
+    inputs:
+      pwsh: true
+      filePath: '..\BCDevOpsFlows\VerifyAuthContext\VerifyAuthContext.ps1'
+      arguments: '-environmentName "$(environmentName)"'
+      warningPreference: 'stop'
+      failOnStderr: true
+      
+  - task: PowerShell@2
     displayName: 'Determine Artifact Url'
     inputs:
       pwsh: true


### PR DESCRIPTION
This pull request includes updates to the Azure Pipelines configuration files to add a new task for verifying the authentication context before proceeding with subsequent tasks. The changes ensure that the authentication context is verified in both the CI/CD and production publishing pipelines.

### Updates to Azure Pipelines configuration:

* [`.azure-pipelines/CICD.yml`](diffhunk://#diff-6123d6c00a9817f8241f81e96c70fc1007b2883c9b6af2151caa4cf957807c4cR46-R57): Added a new PowerShell task `Verify Auth Context` to verify the authentication context before proceeding with the remaining tasks. This task runs only if the previous tasks have succeeded.

* [`.azure-pipelines/PublishToProduction.yml`](diffhunk://#diff-77f12e03c1aa0f850d919368ec9823efd90d5e4f81b6c98b98d9a7264ba994e4R46-R57): Added a similar PowerShell task `Verify Auth Context` to the production pipeline to ensure the authentication context is verified before continuing with the deployment process. This task also runs only if the previous tasks have succeeded.