### PR TITLE
Deploy to more than one environment

### DIFF
--- a/.azure-pipelines/CICD.yml
+++ b/.azure-pipelines/CICD.yml
@@ -23,7 +23,7 @@ jobs:
   timeoutInMinutes: 300
   variables:
     AL_PIPELINENAME: 'CICD'
-    environmentName: $(AL_CICD_ENVIRONMENTNAME)
+    environmentsNameFilter: $(AL_CICD_ENVIRONMENTNAMEFILTERS)
 
   steps:
   - checkout: self
@@ -51,7 +51,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: '..\BCDevOpsFlows\VerifyAuthContext\VerifyAuthContext.ps1'
-      arguments: '-environmentName "$(environmentName)"'
+      arguments: '-environmentsNameFilter "$(environmentsNameFilter)"'
       warningPreference: 'stop'
       failOnStderr: true
       
@@ -88,7 +88,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: '..\BCDevOpsFlows\DeployToCloud\DeployToCloud.ps1'
-      arguments: '-environmentName "$(environmentName)" -deploymentType "Publish"'
+      arguments: '-deployToEnvironmentsNameFilter "$(environmentsNameFilter)" -deploymentType "Publish"'
       warningPreference: 'continue'
       failOnStderr: true
 

--- a/.azure-pipelines/PublishToProduction.yml
+++ b/.azure-pipelines/PublishToProduction.yml
@@ -23,7 +23,7 @@ jobs:
   timeoutInMinutes: 300
   variables:
     AL_PIPELINENAME: 'PublishToProduction'
-    environmentName: $(AL_PROD_ENVIRONMENTNAME)
+    environmentsNameFilter: $(AL_PROD_ENVIRONMENTNAMESFILTER)
 
   steps:
   - checkout: self
@@ -51,7 +51,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: '..\BCDevOpsFlows\VerifyAuthContext\VerifyAuthContext.ps1'
-      arguments: '-environmentName "$(environmentName)"'
+      arguments: '-environmentsNameFilter "$(environmentsNameFilter)"'
       warningPreference: 'stop'
       failOnStderr: true
       
@@ -87,7 +87,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: '..\BCDevOpsFlows\DeployToCloud\DeployToCloud.ps1'
-      arguments: '-environmentName "$(environmentName)" -deploymentType "Publish"'
+      arguments: '-deployToEnvironmentsNameFilter "$(environmentsNameFilter)" -deploymentType "Publish"'
       warningPreference: 'continue'
       failOnStderr: true
 


### PR DESCRIPTION
This pull request includes changes to the Azure Pipelines configuration files to update the variable names and arguments for environment filters. The most important changes include updating the environment name variables and modifying the arguments in PowerShell script steps to use the new filter variables.

Updates to environment variable names:

* [`.azure-pipelines/CICD.yml`](diffhunk://#diff-6123d6c00a9817f8241f81e96c70fc1007b2883c9b6af2151caa4cf957807c4cL26-R26): Changed `environmentName` to `environmentsNameFilter` for the variable definition.
* [`.azure-pipelines/PublishToProduction.yml`](diffhunk://#diff-77f12e03c1aa0f850d919368ec9823efd90d5e4f81b6c98b98d9a7264ba994e4L26-R26): Changed `environmentName` to `environmentsNameFilter` for the variable definition.

Modifications to PowerShell script arguments:

* [`.azure-pipelines/CICD.yml`](diffhunk://#diff-6123d6c00a9817f8241f81e96c70fc1007b2883c9b6af2151caa4cf957807c4cL54-R54): Updated the `arguments` for `VerifyAuthContext.ps1` to use `-environmentsNameFilter` instead of `-environmentName`.
* [`.azure-pipelines/CICD.yml`](diffhunk://#diff-6123d6c00a9817f8241f81e96c70fc1007b2883c9b6af2151caa4cf957807c4cL91-R91): Updated the `arguments` for `DeployToCloud.ps1` to use `-deployToEnvironmentsNameFilter` instead of `-environmentName`.
* [`.azure-pipelines/PublishToProduction.yml`](diffhunk://#diff-77f12e03c1aa0f850d919368ec9823efd90d5e4f81b6c98b98d9a7264ba994e4L54-R54): Updated the `arguments` for `VerifyAuthContext.ps1` to use `-environmentsNameFilter` instead of `-environmentName`.
* [`.azure-pipelines/PublishToProduction.yml`](diffhunk://#diff-77f12e03c1aa0f850d919368ec9823efd90d5e4f81b6c98b98d9a7264ba994e4L90-R90): Updated the `arguments` for `DeployToCloud.ps1` to use `-deployToEnvironmentsNameFilter` instead of `-environmentName`.