### PR TITLE
Use updateVersionNumber from setting when specified

### DIFF
--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -63,6 +63,14 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
+    displayName: Increment Version (if configured)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\IncrementVersion\IncrementVersion.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Build with Nuget
     inputs:
       pwsh: true

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -63,6 +63,14 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
+    displayName: Increment Version (if configured)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\IncrementVersion\IncrementVersion.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Build with Nuget
     inputs:
       pwsh: true


### PR DESCRIPTION
This pull request introduces a new PowerShell task to increment the version of the application, if configured, in two Azure Pipelines templates. The change ensures versioning is handled consistently across different pipeline stages.

### Pipeline updates:

* [`.azure-pipelines/Templates/CICD.yml`](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217R65-R72): Added a `PowerShell@2` task to increment the version using the `IncrementVersion.ps1` script, with configurations to handle warnings and errors appropriately.
* [`.azure-pipelines/Templates/PublishToProduction.yml`](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88R65-R72): Added a `PowerShell@2` task to increment the version using the `IncrementVersion.ps1` script, ensuring consistent versioning in the production pipeline.