### PR TITLE
Remove internals visible - disabled in TestXXX pipelines

### DIFF
--- a/.azure-pipelines/Templates/TestCurrent.Settings.json
+++ b/.azure-pipelines/Templates/TestCurrent.Settings.json
@@ -1,5 +1,6 @@
 {
   "artifact": "////latest",
+  "removeInternalsVisibleTo": false,
   "workflowSchedule": {
     "cron": "0 2 * * 4",
     "displayName": "Every Thursday at 2am",

--- a/.azure-pipelines/Templates/TestNextMajor.Settings.json
+++ b/.azure-pipelines/Templates/TestNextMajor.Settings.json
@@ -1,5 +1,6 @@
 {
   "artifact": "////nextmajor",
+  "removeInternalsVisibleTo": false,
   "workflowSchedule": {
     "cron": "0 2 15 * *",
     "displayName": "Fifteenth of every month",

--- a/.azure-pipelines/Templates/TestNextMinor.Settings.json
+++ b/.azure-pipelines/Templates/TestNextMinor.Settings.json
@@ -1,5 +1,6 @@
 {
   "artifact": "////nextminor",
+  "removeInternalsVisibleTo": false,
   "workflowSchedule": {
     "cron": "0 2 5 * *",
     "displayName": "Fifth of every month",


### PR DESCRIPTION
This pull request introduces a new setting, `removeInternalsVisibleTo`, to multiple Azure Pipelines configuration files. The setting is added with a default value of `false` to ensure consistency across different testing workflows.

Changes to Azure Pipelines configuration:

* [`.azure-pipelines/Templates/TestCurrent.Settings.json`](diffhunk://#diff-516bda13aff53a51dde132b607ba416b43b71d0fa2331b8031927badae2158dbR3): Added the `removeInternalsVisibleTo` setting with a default value of `false`.
* [`.azure-pipelines/Templates/TestNextMajor.Settings.json`](diffhunk://#diff-ce93676ef1f44cefe27a88fb1ca2b6a3fdd1b2af741378f3e71bb374fb5c5c98R3): Added the `removeInternalsVisibleTo` setting with a default value of `false`.
* [`.azure-pipelines/Templates/TestNextMinor.Settings.json`](diffhunk://#diff-2d6b16eab198f2ebf0607a1e0bafef66006a65ed67be158bb0e172c9db339adeR3): Added the `removeInternalsVisibleTo` setting with a default value of `false`.