### PR TITLE
Release 0.02.03 beta 3

### DIFF
--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -20,6 +20,8 @@ jobs:
   steps:
   - checkout: self
     path: App
+    persistCredentials: true
+    clean: true
   - checkout: BCDevOpsFlows
     path: BCDevOpsFlows
   - task: NuGetToolInstaller@1

--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -89,6 +89,14 @@ jobs:
       arguments: -isPreview
       failOnStderr: true
   - task: PowerShell@2
+    displayName: Push Changes Back to Repo (if any)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\PushBackToRepo\PushBackToRepo.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Deploy to Cloud
     condition: and(succeeded(),ne(variables['AL_AUTHCONTEXT'],''))
     env:

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -20,6 +20,8 @@ jobs:
   steps:
   - checkout: self
     path: App
+    persistCredentials: true
+    clean: true
   - checkout: BCDevOpsFlows
     path: BCDevOpsFlows
   - task: NuGetToolInstaller@1

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -88,6 +88,14 @@ jobs:
       filePath: ..\BCDevOpsFlows\DeliverAppFile\DeliverAppFile.ps1
       failOnStderr: true
   - task: PowerShell@2
+    displayName: Push Changes Back to Repo (if any)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\PushBackToRepo\PushBackToRepo.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Deploy to Cloud
     condition: and(succeeded(),ne(variables['AL_AUTHCONTEXT'],''))
     env:

--- a/.azure-pipelines/Templates/PullRequest.yml
+++ b/.azure-pipelines/Templates/PullRequest.yml
@@ -67,7 +67,7 @@ jobs:
       testResultsFiles: '**/$(testResults)'
       searchFolder: $(Common.TestResultsDirectory)
       failTaskOnFailedTests: true
-      failTaskOnFailureToPublishResults: true
+      failTaskOnFailureToPublishResults: $(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)
   - task: PowerShell@2
     displayName: Cleanup
     condition: always()

--- a/.azure-pipelines/Templates/TestCurrent.yml
+++ b/.azure-pipelines/Templates/TestCurrent.yml
@@ -68,7 +68,7 @@ jobs:
       testResultsFiles: '**/$(testResults)'
       searchFolder: $(Common.TestResultsDirectory)
       failTaskOnFailedTests: true
-      failTaskOnFailureToPublishResults: true
+      failTaskOnFailureToPublishResults: $(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)
   - task: PowerShell@2
     displayName: Cleanup
     condition: always()

--- a/.azure-pipelines/Templates/TestNextMajor.yml
+++ b/.azure-pipelines/Templates/TestNextMajor.yml
@@ -68,7 +68,7 @@ jobs:
       testResultsFiles: '**/$(testResults)'
       searchFolder: $(Common.TestResultsDirectory)
       failTaskOnFailedTests: true
-      failTaskOnFailureToPublishResults: true
+      failTaskOnFailureToPublishResults: $(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)
   - task: PowerShell@2
     displayName: Cleanup
     condition: always()

--- a/.azure-pipelines/Templates/TestNextMinor.yml
+++ b/.azure-pipelines/Templates/TestNextMinor.yml
@@ -68,7 +68,7 @@ jobs:
       testResultsFiles: '**/$(testResults)'
       searchFolder: $(Common.TestResultsDirectory)
       failTaskOnFailedTests: true
-      failTaskOnFailureToPublishResults: true
+      failTaskOnFailureToPublishResults: $(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)
   - task: PowerShell@2
     displayName: Cleanup
     condition: always()


### PR DESCRIPTION
This pull request introduces updates to several Azure Pipelines YAML templates to enhance functionality and flexibility. The most important changes include improvements to repository checkout steps, the addition of a task to push changes back to the repository, and the parameterization of test result publishing behavior.

### Enhancements to repository checkout:

* Added `persistCredentials: true` and `clean: true` to the `checkout` steps in `.azure-pipelines/Templates/CICD.yml` and `.azure-pipelines/Templates/PublishToProduction.yml` to ensure credentials persist across steps and the working directory is cleaned before checkout. [[1]](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217R23-R24) [[2]](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88R23-R24)

### New task for pushing changes back to the repository:

* Introduced a new `PowerShell@2` task in `.azure-pipelines/Templates/CICD.yml` and `.azure-pipelines/Templates/PublishToProduction.yml` to push changes back to the repository, with settings for handling warnings and errors. [[1]](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217R93-R100) [[2]](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88R92-R99)

### Parameterization of test result publishing:

* Replaced the hardcoded `failTaskOnFailureToPublishResults: true` with the parameterized variable `$(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)` in `.azure-pipelines/Templates/PullRequest.yml`, `.azure-pipelines/Templates/TestCurrent.yml`, `.azure-pipelines/Templates/TestNextMajor.yml`, and `.azure-pipelines/Templates/TestNextMinor.yml` to allow configurable behavior for test result publishing. [[1]](diffhunk://#diff-5ae89b2254787cad0769a07574d166dd4d82a2bb96e259a6647d9555304b9c97L70-R70) [[2]](diffhunk://#diff-63a0a8fa500538f4a71b03d30e86ee4b90bdd12f830fa74155e3926dba128113L71-R71) [[3]](diffhunk://#diff-a717f0c81097306e30b98c8ceb9124ced821b7ee43858a2a88b311304826520aL71-R71) [[4]](diffhunk://#diff-8f4c560f1e99485b3a9f5e7e613d9b03417d8cba3221290b989256d585afc5bdL71-R71)