### PR TITLE
Push changes back to repos

### DIFF
--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -63,6 +63,14 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
+    displayName: Increment Version (if configured)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\IncrementVersion\IncrementVersion.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Build with Nuget
     inputs:
       pwsh: true

--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -89,6 +89,14 @@ jobs:
       arguments: -isPreview
       failOnStderr: true
   - task: PowerShell@2
+    displayName: Push Changes Back to Repo (if any)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\PushBackToRepo\PushBackToRepo.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Deploy to Cloud
     condition: and(succeeded(),ne(variables['AL_AUTHCONTEXT'],''))
     env:

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -63,6 +63,14 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
+    displayName: Increment Version (if configured)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\IncrementVersion\IncrementVersion.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Build with Nuget
     inputs:
       pwsh: true

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -88,6 +88,14 @@ jobs:
       filePath: ..\BCDevOpsFlows\DeliverAppFile\DeliverAppFile.ps1
       failOnStderr: true
   - task: PowerShell@2
+    displayName: Push Changes Back to Repo (if any)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\PushBackToRepo\PushBackToRepo.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Deploy to Cloud
     condition: and(succeeded(),ne(variables['AL_AUTHCONTEXT'],''))
     env:


### PR DESCRIPTION
This pull request introduces a new step to push changes back to the repository in two Azure Pipelines YAML templates. The change ensures that any modifications made during the pipeline execution are committed back to the repository.

### Additions to pipeline workflows:

* [`.azure-pipelines/Templates/CICD.yml`](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217R91-R98): Added a new PowerShell task, `Push Changes Back to Repo (if any)`, to push changes back to the repository. This task uses the `PushBackToRepo.ps1` script and includes options to handle warnings gracefully.
* [`.azure-pipelines/Templates/PublishToProduction.yml`](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88R90-R97): Added the same `Push Changes Back to Repo (if any)` PowerShell task to ensure consistency across environments.