### PR TITLE
Push changes back to repos - fixes

### DIFF
--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -20,6 +20,8 @@ jobs:
   steps:
   - checkout: self
     path: App
+    persistCredentials: true
+    clean: true
   - checkout: BCDevOpsFlows
     path: BCDevOpsFlows
   - task: NuGetToolInstaller@1

--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -63,6 +63,14 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
+    displayName: Increment Version (if configured)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\IncrementVersion\IncrementVersion.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Build with Nuget
     inputs:
       pwsh: true

--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -89,6 +89,14 @@ jobs:
       arguments: -isPreview
       failOnStderr: true
   - task: PowerShell@2
+    displayName: Push Changes Back to Repo (if any)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\PushBackToRepo\PushBackToRepo.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Deploy to Cloud
     condition: and(succeeded(),ne(variables['AL_AUTHCONTEXT'],''))
     env:

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -20,6 +20,8 @@ jobs:
   steps:
   - checkout: self
     path: App
+    persistCredentials: true
+    clean: true
   - checkout: BCDevOpsFlows
     path: BCDevOpsFlows
   - task: NuGetToolInstaller@1

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -63,6 +63,14 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
+    displayName: Increment Version (if configured)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\IncrementVersion\IncrementVersion.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Build with Nuget
     inputs:
       pwsh: true

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -88,6 +88,14 @@ jobs:
       filePath: ..\BCDevOpsFlows\DeliverAppFile\DeliverAppFile.ps1
       failOnStderr: true
   - task: PowerShell@2
+    displayName: Push Changes Back to Repo (if any)
+    inputs:
+      pwsh: true
+      filePath: ..\BCDevOpsFlows\PushBackToRepo\PushBackToRepo.ps1
+      failOnStderr: true
+      warningPreference: continue
+      showWarnings: true
+  - task: PowerShell@2
     displayName: Deploy to Cloud
     condition: and(succeeded(),ne(variables['AL_AUTHCONTEXT'],''))
     env:


### PR DESCRIPTION
This pull request introduces updates to the Azure Pipelines YAML templates to enhance pipeline functionality and ensure proper repository management. The key changes include enabling credential persistence and repository cleanup during checkouts, as well as adding a new task to push changes back to the repository.

### Enhancements to repository management:

* [`.azure-pipelines/Templates/CICD.yml`](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217R23-R24): Added `persistCredentials: true` and `clean: true` to the `checkout` step for the `self` repository to ensure credentials persist and the repository is cleaned during the pipeline run.
* [`.azure-pipelines/Templates/PublishToProduction.yml`](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88R23-R24): Added `persistCredentials: true` and `clean: true` to the `checkout` step for the `self` repository to match the changes in the CICD pipeline.

### New task for pushing changes back to the repository:

* [`.azure-pipelines/Templates/CICD.yml`](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217R93-R100): Introduced a new PowerShell task to push any changes back to the repository, with settings to handle warnings (`warningPreference: continue` and `showWarnings: true`). This task is added before the deployment step.
* [`.azure-pipelines/Templates/PublishToProduction.yml`](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88R92-R99): Added the same PowerShell task for pushing changes back to the repository, ensuring consistency across pipelines.