### PR TITLE
Stop when warning in build pipeline step

### DIFF
--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -77,7 +77,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\BuildWithNuget\BuildWithNuget.ps1
-      warningPreference: continue
+      warningPreference: stop
       showWarnings: true
       failOnStderr: true
   - task: PowerShell@2

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -77,7 +77,7 @@ jobs:
     inputs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\BuildWithNuget\BuildWithNuget.ps1
-      warningPreference: continue
+      warningPreference: stop
       showWarnings: true
       failOnStderr: true
   - task: PowerShell@2

--- a/.azure-pipelines/Templates/PullRequest.yml
+++ b/.azure-pipelines/Templates/PullRequest.yml
@@ -56,7 +56,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: continue
+      warningPreference: stop
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2

--- a/.azure-pipelines/Templates/TestCurrent.yml
+++ b/.azure-pipelines/Templates/TestCurrent.yml
@@ -57,7 +57,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: continue
+      warningPreference: stop
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2

--- a/.azure-pipelines/Templates/TestNextMajor.yml
+++ b/.azure-pipelines/Templates/TestNextMajor.yml
@@ -57,7 +57,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: continue
+      warningPreference: stop
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2

--- a/.azure-pipelines/Templates/TestNextMinor.yml
+++ b/.azure-pipelines/Templates/TestNextMinor.yml
@@ -57,7 +57,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: continue
+      warningPreference: stop
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2


### PR DESCRIPTION
This pull request updates the `warningPreference` setting across multiple Azure Pipelines templates to enforce stricter error handling by changing its value from `continue` to `stop`. This ensures that warnings in PowerShell tasks are treated as errors, improving pipeline robustness and reliability.

### Pipeline Configuration Updates:

* [`.azure-pipelines/Templates/CICD.yml`](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217L80-R80): Changed `warningPreference` from `continue` to `stop` in the PowerShell task to halt execution on warnings.
* [`.azure-pipelines/Templates/PublishToProduction.yml`](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88L80-R80): Updated `warningPreference` to `stop` to ensure warnings are treated as errors during production publishing.

### Testing Pipeline Updates:

* [`.azure-pipelines/Templates/PullRequest.yml`](diffhunk://#diff-5ae89b2254787cad0769a07574d166dd4d82a2bb96e259a6647d9555304b9c97L59-R59): Modified `warningPreference` to `stop` to enforce stricter error handling in pull request pipelines.
* [`.azure-pipelines/Templates/TestCurrent.yml`](diffhunk://#diff-63a0a8fa500538f4a71b03d30e86ee4b90bdd12f830fa74155e3926dba128113L60-R60): Adjusted `warningPreference` to `stop` for the current version testing pipeline.
* [`.azure-pipelines/Templates/TestNextMajor.yml`](diffhunk://#diff-a717f0c81097306e30b98c8ceb9124ced821b7ee43858a2a88b311304826520aL60-R60): Set `warningPreference` to `stop` for the next major version testing pipeline.
* [`.azure-pipelines/Templates/TestNextMinor.yml`](diffhunk://#diff-8f4c560f1e99485b3a9f5e7e613d9b03417d8cba3221290b989256d585afc5bdL60-R60): Updated `warningPreference` to `stop` for the next minor version testing pipeline.