### PR TITLE
Merge run with NuGet with run with BCContainerHelper

### DIFF
--- a/.azure-pipelines/BCDevOpsFlows.Settings.json
+++ b/.azure-pipelines/BCDevOpsFlows.Settings.json
@@ -7,6 +7,7 @@
   "testFolders": [
     "Test"
   ],
+  "runWith": "BCContainerHelper",
   "versioningStrategy": 0,
   "cacheImageName": ""
 }

--- a/.azure-pipelines/Templates/CICD.Settings.json
+++ b/.azure-pipelines/Templates/CICD.Settings.json
@@ -6,6 +6,7 @@
   "enableUICop": false,
   "enableAppSourceCop": false,
   "enablePerTenantExtensionCop": false,
+  "runWith": "NuGet",
   "workflowTrigger": {
     "batch": true,
     "branches": {

--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -56,12 +56,12 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\InitNuget\InitNuget.ps1
   - task: PowerShell@2
-    displayName: Determine Nuget Packages
+    displayName: Determine Packages
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\DetermineNugetPackages\DetermineNugetPackages.ps1
+      filePath: ..\BCDevOpsFlows\DeterminePackages\DeterminePackages.ps1
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
@@ -73,10 +73,13 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
-    displayName: Build with Nuget
+    displayName: Build
+    env:
+      AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\BuildWithNuget\BuildWithNuget.ps1
+      filePath: ..\BCDevOpsFlows\Build\Build.ps1
+      arguments: -artifact "$(AL_ARTIFACT)"
       warningPreference: continue
       showWarnings: true
       failOnStderr: true

--- a/.azure-pipelines/Templates/CICD.yml
+++ b/.azure-pipelines/Templates/CICD.yml
@@ -83,6 +83,15 @@ jobs:
       warningPreference: continue
       showWarnings: true
       failOnStderr: true
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    condition: and(succeeded(),ne(variables['TestResults'],''))
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: '**/$(testResults)'
+      searchFolder: $(Common.TestResultsDirectory)
+      failTaskOnFailedTests: true
+      failTaskOnFailureToPublishResults: $(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)
   - task: PowerShell@2
     displayName: Deliver App Files
     condition: succeeded()

--- a/.azure-pipelines/Templates/PublishToProduction.Settings.json
+++ b/.azure-pipelines/Templates/PublishToProduction.Settings.json
@@ -6,6 +6,7 @@
   "enableUICop": false,
   "enableAppSourceCop": false,
   "enablePerTenantExtensionCop": false,
+  "runWith": "NuGet",
   "workflowTrigger": {
     "batch": true,
     "branches": {

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -56,12 +56,12 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\InitNuget\InitNuget.ps1
   - task: PowerShell@2
-    displayName: Determine Nuget Packages
+    displayName: Determine Packages
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\DetermineNugetPackages\DetermineNugetPackages.ps1
+      filePath: ..\BCDevOpsFlows\DeterminePackages\DeterminePackages.ps1
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
@@ -73,10 +73,13 @@ jobs:
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
-    displayName: Build with Nuget
+    displayName: Build
+    env:
+      AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\BuildWithNuget\BuildWithNuget.ps1
+      filePath: ..\BCDevOpsFlows\Build\Build.ps1
+      arguments: -artifact "$(AL_ARTIFACT)"
       warningPreference: continue
       showWarnings: true
       failOnStderr: true

--- a/.azure-pipelines/Templates/PublishToProduction.yml
+++ b/.azure-pipelines/Templates/PublishToProduction.yml
@@ -83,6 +83,15 @@ jobs:
       warningPreference: continue
       showWarnings: true
       failOnStderr: true
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    condition: and(succeeded(),ne(variables['TestResults'],''))
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: '**/$(testResults)'
+      searchFolder: $(Common.TestResultsDirectory)
+      failTaskOnFailedTests: true
+      failTaskOnFailureToPublishResults: $(AL_FAILPUBLISHTESTSONFAILURETOPUBLISHRESULTS)
   - task: PowerShell@2
     displayName: Deliver App Files
     condition: succeeded()

--- a/.azure-pipelines/Templates/PullRequest.yml
+++ b/.azure-pipelines/Templates/PullRequest.yml
@@ -56,7 +56,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: stop
+      warningPreference: continue
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2

--- a/.azure-pipelines/Templates/PullRequest.yml
+++ b/.azure-pipelines/Templates/PullRequest.yml
@@ -40,21 +40,21 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\InitNuget\InitNuget.ps1
   - task: PowerShell@2
-    displayName: Determine Artifact Url
+    displayName: Determine Packages
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\DetermineArtifactUrl\DetermineArtifactUrl.ps1
+      filePath: ..\BCDevOpsFlows\DeterminePackages\DeterminePackages.ps1
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
-    displayName: Run Pipeline (Build)
+    displayName: Build
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
+      filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
       warningPreference: continue
       showWarnings: true

--- a/.azure-pipelines/Templates/TestCurrent.yml
+++ b/.azure-pipelines/Templates/TestCurrent.yml
@@ -41,21 +41,21 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\InitNuget\InitNuget.ps1
   - task: PowerShell@2
-    displayName: Determine Artifact Url
+    displayName: Determine Packages
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\DetermineArtifactUrl\DetermineArtifactUrl.ps1
+      filePath: ..\BCDevOpsFlows\DeterminePackages\DeterminePackages.ps1
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
-    displayName: Run Pipeline (Build)
+    displayName: Build
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
+      filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
       warningPreference: continue
       showWarnings: true

--- a/.azure-pipelines/Templates/TestCurrent.yml
+++ b/.azure-pipelines/Templates/TestCurrent.yml
@@ -57,7 +57,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: stop
+      warningPreference: continue
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2

--- a/.azure-pipelines/Templates/TestNextMajor.yml
+++ b/.azure-pipelines/Templates/TestNextMajor.yml
@@ -41,21 +41,21 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\InitNuget\InitNuget.ps1
   - task: PowerShell@2
-    displayName: Determine Artifact Url
+    displayName: Determine Packages
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\DetermineArtifactUrl\DetermineArtifactUrl.ps1
+      filePath: ..\BCDevOpsFlows\DeterminePackages\DeterminePackages.ps1
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
-    displayName: Run Pipeline (Build)
+    displayName: Build
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
+      filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
       warningPreference: continue
       showWarnings: true

--- a/.azure-pipelines/Templates/TestNextMajor.yml
+++ b/.azure-pipelines/Templates/TestNextMajor.yml
@@ -57,7 +57,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: stop
+      warningPreference: continue
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2

--- a/.azure-pipelines/Templates/TestNextMinor.yml
+++ b/.azure-pipelines/Templates/TestNextMinor.yml
@@ -41,21 +41,21 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\InitNuget\InitNuget.ps1
   - task: PowerShell@2
-    displayName: Determine Artifact Url
+    displayName: Determine Packages
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\DetermineArtifactUrl\DetermineArtifactUrl.ps1
+      filePath: ..\BCDevOpsFlows\DeterminePackages\DeterminePackages.ps1
       warningPreference: continue
       showWarnings: true
   - task: PowerShell@2
-    displayName: Run Pipeline (Build)
+    displayName: Build
     env:
       AL_TRUSTEDNUGETFEEDS_INTERNAL: $(AL_TRUSTEDNUGETFEEDS)
     inputs:
       pwsh: true
-      filePath: ..\BCDevOpsFlows\RunPipeline\RunPipeline.ps1
+      filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
       warningPreference: continue
       showWarnings: true

--- a/.azure-pipelines/Templates/TestNextMinor.yml
+++ b/.azure-pipelines/Templates/TestNextMinor.yml
@@ -57,7 +57,7 @@ jobs:
       pwsh: true
       filePath: ..\BCDevOpsFlows\Build\Build.ps1
       arguments: -artifact "$(AL_ARTIFACT)"
-      warningPreference: stop
+      warningPreference: continue
       showWarnings: true
       failOnStderr: true
   - task: PublishTestResults@2


### PR DESCRIPTION
This pull request introduces changes to the Azure Pipelines configuration files to standardize task naming and script usage across multiple workflows. It also adds support for publishing test results in certain pipelines. The key changes are grouped and summarized below:

### Standardization of Task Names and Script Paths:
* Updated task display names to use consistent terminology, such as changing "Determine Nuget Packages" to "Determine Packages" and "Run Pipeline (Build)" to "Build." (`.azure-pipelines/Templates/CICD.yml`, `.azure-pipelines/Templates/PublishToProduction.yml`, `.azure-pipelines/Templates/PullRequest.yml`, `.azure-pipelines/Templates/TestCurrent.yml`, `.azure-pipelines/Templates/TestNextMajor.yml`, `.azure-pipelines/Templates/TestNextMinor.yml`) [[1]](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217L59-R64) [[2]](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88L59-R64) [[3]](diffhunk://#diff-5ae89b2254787cad0769a07574d166dd4d82a2bb96e259a6647d9555304b9c97L43-R57) [[4]](diffhunk://#diff-63a0a8fa500538f4a71b03d30e86ee4b90bdd12f830fa74155e3926dba128113L44-R58) [[5]](diffhunk://#diff-a717f0c81097306e30b98c8ceb9124ced821b7ee43858a2a88b311304826520aL44-R58) [[6]](diffhunk://#diff-8f4c560f1e99485b3a9f5e7e613d9b03417d8cba3221290b989256d585afc5bdL44-R58)
* Replaced script paths to align with the new folder structure, such as switching from `DetermineNugetPackages.ps1` to `DeterminePackages.ps1` and from `RunPipeline.ps1` to `Build.ps1`. (`.azure-pipelines/Templates/CICD.yml`, `.azure-pipelines/Templates/PublishToProduction.yml`, `.azure-pipelines/Templates/PullRequest.yml`, `.azure-pipelines/Templates/TestCurrent.yml`, `.azure-pipelines/Templates/TestNextMajor.yml`, `.azure-pipelines/Templates/TestNextMinor.yml`) [[1]](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217L59-R64) [[2]](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88L59-R64) [[3]](diffhunk://#diff-5ae89b2254787cad0769a07574d166dd4d82a2bb96e259a6647d9555304b9c97L43-R57) [[4]](diffhunk://#diff-63a0a8fa500538f4a71b03d30e86ee4b90bdd12f830fa74155e3926dba128113L44-R58) [[5]](diffhunk://#diff-a717f0c81097306e30b98c8ceb9124ced821b7ee43858a2a88b311304826520aL44-R58) [[6]](diffhunk://#diff-8f4c560f1e99485b3a9f5e7e613d9b03417d8cba3221290b989256d585afc5bdL44-R58)

### Introduction of Test Results Publishing:
* Added a new step to publish test results in JUnit format, with conditions to ensure it only runs when tests are present and the pipeline succeeds. (`.azure-pipelines/Templates/CICD.yml`, `.azure-pipelines/Templates/PublishToProduction.yml`) [[1]](diffhunk://#diff-0cd24d92c81cd1de453106c092ac949f65ff1c427022a0c42aa3d85ff2dcb217L76-R94) [[2]](diffhunk://#diff-bf5ba41c0db7733fb28b819e989a86bff6ab382ffe0c50453b99643f40671b88L76-R94)

### Configuration Enhancements:
* Added a `runWith` property to specify the tool used in various settings files. For example, `BCContainerHelper` was added to `.azure-pipelines/BCDevOpsFlows.Settings.json`, and `NuGet` was added to `.azure-pipelines/Templates/CICD.Settings.json` and `.azure-pipelines/Templates/PublishToProduction.Settings.json`. [[1]](diffhunk://#diff-f75db2bf2da0c1fe1ede6d8847e5e1fa538e43a2c23f811a79bf38382931af02R10) [[2]](diffhunk://#diff-588d437ee41ad411a54d77297a8e79f5b0444ff854e9a8daa917311998976ae1R9) [[3]](diffhunk://#diff-c1c01c030bc4769e9b0d852529dd98b4ff1e9ec0dbf0e308ac9853e97e2a244bR9)