### PR TITLE
FailOn - default settings

### DIFF
--- a/.azure-pipelines/BCDevOpsFlows.Settings.json
+++ b/.azure-pipelines/BCDevOpsFlows.Settings.json
@@ -8,6 +8,7 @@
     "Test"
   ],
   "runWith": "BCContainerHelper",
+  "failOn": "Error",
   "versioningStrategy": 0,
   "cacheImageName": ""
 }

--- a/.azure-pipelines/Templates/PullRequest.Settings.json
+++ b/.azure-pipelines/Templates/PullRequest.Settings.json
@@ -1,4 +1,5 @@
 {
   "artifact": "////latest",
-  "removeInternalsVisibleTo": false
+  "removeInternalsVisibleTo": false,
+  "failOn": "Warning"
 }


### PR DESCRIPTION
This pull request introduces updates to pipeline configuration files to enhance error handling during pipeline execution. Specifically, it adds new `failOn` properties to define failure conditions based on error levels.

### Pipeline configuration updates:

* [`.azure-pipelines/BCDevOpsFlows.Settings.json`](diffhunk://#diff-f75db2bf2da0c1fe1ede6d8847e5e1fa538e43a2c23f811a79bf38382931af02R11): Added a `failOn` property with the value `"Error"` to ensure the pipeline fails on errors.
* [`.azure-pipelines/Templates/PullRequest.Settings.json`](diffhunk://#diff-5be90874c35404d462c4aed8d49db0baeb6414edfe363946107ce554232610b3L3-R4): Added a `failOn` property with the value `"Warning"` to make the pipeline fail on warnings during pull request builds.