### PR TITLE
skipUpgrade for TestXXX pipelines

### DIFF
--- a/.azure-pipelines/Templates/TestCurrent.Settings.json
+++ b/.azure-pipelines/Templates/TestCurrent.Settings.json
@@ -1,5 +1,6 @@
 {
   "artifact": "////latest",
+  "skipUpgrade": true,
   "removeInternalsVisibleTo": false,
   "workflowSchedule": {
     "cron": "0 2 * * 4",

--- a/.azure-pipelines/Templates/TestNextMajor.Settings.json
+++ b/.azure-pipelines/Templates/TestNextMajor.Settings.json
@@ -1,5 +1,6 @@
 {
   "artifact": "////nextmajor",
+  "skipUpgrade": true,
   "removeInternalsVisibleTo": false,
   "workflowSchedule": {
     "cron": "0 2 15 * *",

--- a/.azure-pipelines/Templates/TestNextMinor.Settings.json
+++ b/.azure-pipelines/Templates/TestNextMinor.Settings.json
@@ -1,5 +1,6 @@
 {
   "artifact": "////nextminor",
+  "skipUpgrade": true,
   "removeInternalsVisibleTo": false,
   "workflowSchedule": {
     "cron": "0 2 5 * *",


### PR DESCRIPTION
This pull request updates the pipeline configuration settings across multiple test environments to include a new `skipUpgrade` flag. This flag is set to `true` in all affected configuration files.

Pipeline configuration updates:

* [`.azure-pipelines/Templates/TestCurrent.Settings.json`](diffhunk://#diff-516bda13aff53a51dde132b607ba416b43b71d0fa2331b8031927badae2158dbR3): Added the `skipUpgrade` flag with a value of `true`.
* [`.azure-pipelines/Templates/TestNextMajor.Settings.json`](diffhunk://#diff-ce93676ef1f44cefe27a88fb1ca2b6a3fdd1b2af741378f3e71bb374fb5c5c98R3): Added the `skipUpgrade` flag with a value of `true`.
* [`.azure-pipelines/Templates/TestNextMinor.Settings.json`](diffhunk://#diff-2d6b16eab198f2ebf0607a1e0bafef66006a65ed67be158bb0e172c9db339adeR3): Added the `skipUpgrade` flag with a value of `true`.